### PR TITLE
Allow for developers to use questcraft MCXR as a build.gradle dependency.

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,34 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Maven Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 17
+      uses: actions/setup-java@v2
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Publish to GitHub Packages Apache Maven
+      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,25 @@
 static def getVersionMetadata(var project) {
     return null;
 }
-plugins {
-    id 'maven-publish'
+
+allprojects {
+    group = 'com.github.QuestCraftPlusPlus'
 }
+
+subprojects {
+
+    apply plugin: 'maven-publish'
+
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                groupId project.group
+                artifactId project.name
+                version project.questcraft_version
+            }
+        }
+    }
+
+}
+
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@ org.gradle.jvmargs=-Xmx1G
 # Mod Properties
 	core_version = 0.1.1
 	play_version = 0.1.3
+	questcraft_version = 1.1.1
 	maven_group = net.sorenon
 
 # Dependencies

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17


### PR DESCRIPTION
I've added the necessary files for devs to add Questcraft MCXR as a dependency through jitpack in their build.gradle files. This allows for devs to extend functionality of their mods by integrating more with questcraft.