### PR TITLE
Add F3 toggle button to Quick Menu

### DIFF
--- a/mcxr-play/src/main/java/net/sorenon/mcxr/play/compat/svc/SimpleVoiceChatCompat.java
+++ b/mcxr-play/src/main/java/net/sorenon/mcxr/play/compat/svc/SimpleVoiceChatCompat.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 
 public class SimpleVoiceChatCompat {
     public static void createButton(ArrayList<Button> buttons, int width, int height) {
-        buttons.add(new Button((width/2) - 25, height/2 + 20, 70+ Minecraft.getInstance().font.width("Simple Voice Chat Settings"), 20, new TranslatableComponent("Simple Voice Chat Settings"), (button) -> {
+        buttons.add(new Button((width/2) - 25, height/2 + 40, 70+ Minecraft.getInstance().font.width("Simple Voice Chat Settings"), 20, new TranslatableComponent("Simple Voice Chat Settings"), (button) -> {
             Minecraft.getInstance().setScreen(new VoiceChatScreen());
         }));
     }

--- a/mcxr-play/src/main/java/net/sorenon/mcxr/play/gui/QuickMenu.java
+++ b/mcxr-play/src/main/java/net/sorenon/mcxr/play/gui/QuickMenu.java
@@ -27,6 +27,9 @@ public class QuickMenu extends Screen {
         if (FabricLoader.getInstance().isModLoaded("voicechat")) {
             SimpleVoiceChatCompat.createButton(QuickMenuButtons, this.width, this.height);
         }
+        QuickMenuButtons.add(new Button((this.width/2) - 25, this.height/2 + 20, 70, 20, new TranslatableComponent("Toggle F3 Menu"), (button ) -> {
+            Minecraft.getInstance().options.renderDebug = !Minecraft.getInstance().options.renderDebug;
+        }));
 
         for (int i = 0; i < QuickMenuButtons.size(); i++) {
             Button QuickMenuButton = QuickMenuButtons.get(i);


### PR DESCRIPTION
I noticed there's no way to enable the F3 debug menu for QuestCraft, so I made this. I can't test this because I don't have a PCVR-ready PC and  trying to load it into QuestCraft completely broke my installation, but it's a simple enough edit that I think it would work anyway.

Adds a 'Toggle F3' button to the Quick Mennu, and moves the Simple Voice Chat button to make room.